### PR TITLE
Task 3 - added new (open/closed) status field

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,10 @@ I completed the task, including the *'Bonus points'* for ORDER/SORT-BY. The Post
 
 This one contained a potential SQL Injection threat, which I avoided by creating a map and only allowing the caller to specify from the given set of attribute names. The default, should they choose outside of this range, is the `advertised_start_time`. 
 
-I decided to mask the names of our tables though and use the JSON names, which seems more user friendly. 
+I decided to mask the names of our tables though and use the JSON names, which seems more user friendly.
+
+#### Task 3 - Add New Status Field
+
+I completed this challenge by adding a new status field to the proto file. This testing worked well with the multi-test technique and overall it was quite an easy task. 
+
+One thing that is bothering me, as a protobuf *newbie*, is that we have two identical portions of (`racing`) generated code (i.e. [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)). I am thinking that it must be possible and even desirable to include these in a separate but linked repository (I am sure that it has been done!).

--- a/api/proto/racing/racing.proto
+++ b/api/proto/racing/racing.proto
@@ -45,6 +45,12 @@ enum SortDirection {
   DESC = 1;
 }
 
+// Enumberation indicating the race status
+enum RaceStatus {
+  CLOSED = 0;
+  OPEN = 1;
+}
+
 /* Resources */
 
 // A race resource.
@@ -61,4 +67,6 @@ message Race {
   bool visible = 5;
   // AdvertisedStartTime is the time the race is advertised to run.
   google.protobuf.Timestamp advertised_start_time = 6;
+  // Indicates the race status (open or closed).
+  RaceStatus status = 7;
 }

--- a/racing/db/races.go
+++ b/racing/db/races.go
@@ -156,9 +156,19 @@ func (m *racesRepo) scanRaces(
 		}
 
 		race.AdvertisedStartTime = ts
-
+		setRaceStatus(advertisedStart, &race)
 		races = append(races, &race)
 	}
 
 	return races, nil
+}
+
+// Any race that is in the future is considered to be open
+func setRaceStatus(advertisedStartTime time.Time, race *racing.Race) {
+
+	if time.Now().Before(advertisedStartTime) {
+		race.Status = racing.RaceStatus_OPEN
+	} else {
+		race.Status = racing.RaceStatus_CLOSED
+	}
 }

--- a/racing/proto/racing/racing.proto
+++ b/racing/proto/racing/racing.proto
@@ -41,6 +41,12 @@ enum SortDirection {
   DESC = 1;
 }
 
+// Enumberation indicating the race status
+enum RaceStatus {
+  CLOSED = 0;
+  OPEN = 1;
+}
+
 /* Resources */
 
 // A race resource.
@@ -57,5 +63,7 @@ message Race {
   bool visible = 5;
   // AdvertisedStartTime is the time the race is advertised to run.
   google.protobuf.Timestamp advertised_start_time = 6;
+  // Indicates the race status (open or closed).
+  RaceStatus status = 7;
 }
 


### PR DESCRIPTION
1. Added a status indicator based on the advertised start time (i.e. 'Open' or 'Closed')
2. Unit tests, postman collection
3. I removed the proto related files as they are essentially regernerated each time, so no need for them in the repo